### PR TITLE
Fix hard-coded language in `nllb_translation` example.

### DIFF
--- a/examples/translation/nllb_translation.py
+++ b/examples/translation/nllb_translation.py
@@ -66,7 +66,7 @@ def load_mlx_nllb_model(
         model_name, src_lang=source_language, tgt_lang=target_language
     )
 
-    tgt_token_id = tokenizer.convert_tokens_to_ids("yor_Latn")
+    tgt_token_id = tokenizer.convert_tokens_to_ids(target_language)
     return model, tokenizer, tgt_token_id
 
 


### PR DESCRIPTION
## Proposed changes

The target language was accidentally hard-coded to `yor_Latn` (Yoruba) instead of being customizable by the `--target_language` command-line option.

## Types of changes

- [ ] New Model Architecture
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
